### PR TITLE
Check entity in runWave to prevent crash

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_fd.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_fd.nut
@@ -969,7 +969,7 @@ bool function runWave( int waveIndex, bool shouldDoBuyTime )
 		// this function is called "Set" but in reality it is "Add"
 		SetJoinInProgressBonus( GetCurrentPlaylistVarInt( "fd_money_per_round" ,600 ) )
 		if(!IsValidPlayer(player)) {
-			return false
+			continue
 		}
 		EmitSoundOnEntityOnlyToPlayer( player, player, "HUD_MP_BountyHunt_BankBonusPts_Deposit_Start_1P" )
 	}

--- a/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_fd.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_fd.nut
@@ -968,6 +968,9 @@ bool function runWave( int waveIndex, bool shouldDoBuyTime )
 		// is this in the right place? do we want to be adding for each player?
 		// this function is called "Set" but in reality it is "Add"
 		SetJoinInProgressBonus( GetCurrentPlaylistVarInt( "fd_money_per_round" ,600 ) )
+		if(!IsValidPlayer(player)) {
+			return false
+		}
 		EmitSoundOnEntityOnlyToPlayer( player, player, "HUD_MP_BountyHunt_BankBonusPts_Deposit_Start_1P" )
 	}
 	wait 1


### PR DESCRIPTION
Just found a crash on my server that related to a null entity. So I added a player check to prevent the server being crash

![Screenshot-2023-03-10-033321](https://user-images.githubusercontent.com/48656764/224134679-718a57fa-f3ba-4f7f-80a4-70caae3426af.png)
